### PR TITLE
Enhance DIO sample project to demonstrate QueuedInterceptors

### DIFF
--- a/material/08.md
+++ b/material/08.md
@@ -174,9 +174,21 @@ Every callback function also receives a `<Request/Response/Error>InterceptorHand
 
 > In contrast to [`OkHttp`](https://square.github.io/okhttp/)'s interceptor chain, the order of the calls to the interceptors always matches the order they were added, independent of whether the `onRequest()` or `onResponse()/onError()` are called. 
 
-The interceptors can be blocked by calling the `lock()` function on the corresponding interceptor lock. This will stop any request or response from entering the interceptor until the lock is unlocked. The `lock()` and `unlock()` function can also be found in the `Dio` class, which corresponds to the `requestLock()`. This can be useful if we want to block every network request until a token is retrieved from the server.
+If we want to create our interceptor, we can either extend the base `Interceptor` class or use the `InterceptorsWrapper` class to pass the three callback functions as constructor parameters. Besides that we can also use the `QueuedInterceptorsWrapper` class to create a `QueuedInterceptor`.
 
-If we want to create our interceptor, we can either extend the base `Interceptor` class or use the `InterceptorsWrapper` class to pass the three callback functions as constructor parameters. The `dio` library contains a built-in `LogInterceptor()` class, which prints out every request and response to the console. 
+In earlier versions of Dio, controlling the flow through interceptors, especially to block requests for operations like token refresh, might have involved more explicit `lock()` and `unlock()` calls directly on interceptor instances.
+
+Modern Dio, particularly with `QueuedInterceptorsWrapper`, handles this serialization implicitly and more gracefully for the interceptor it wraps. When an interceptor's logic is encapsulated within a `QueuedInterceptorsWrapper`:
+
+*   Its handlers (`onRequest`, `onResponse`, `onError`) are automatically processed **sequentially** if multiple requests arrive concurrently. For example, a second request's `onRequest` handler within this wrapper will wait until the first request's `onRequest` handler has fully completed its processing (including any asynchronous operations that occur before `handler.next()` is called).
+This built-in queuing behavior is highly effective for common scenarios such as token refresh. If a request fails due to an expired token, the `QueuedInterceptorsWrapper` can manage the refresh process, and other pending or subsequent requests that pass through it will naturally queue up, waiting for the new token to be acquired and applied, without requiring manual lock/unlock logic within your interceptor's code for this queuing purpose.
+
+Separately, Dio still offers a **global `dio.lock()` and `dio.unlock()`** mechanism. Calling `dio.lock()` pauses the entire Dio client instance, preventing *all new requests* from being dispatched through the interceptor chain or to the network until `dio.unlock()` is called. This global lock is a broader mechanism, distinct from the automatic, per-handler-type queuing provided by `QueuedInterceptorsWrapper` for the interceptor it manages.
+
+
+
+
+The `dio` library contains a built-in `LogInterceptor()` class, which prints out every request and response to the console. 
 
 Other useful utilities can be found in external libraries:
 

--- a/projects/chapters/chapter_08/flutter_dio/README.md
+++ b/projects/chapters/chapter_08/flutter_dio/README.md
@@ -14,3 +14,112 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Interceptor Chain Explanation
+
+This project demonstrates the use of Dio interceptors, highlighting the difference between `InterceptorsWrapper` and `QueuedInterceptorsWrapper`.
+
+**Interceptor Chain Flow:**
+
+1.  **Interceptor1 (`InterceptorsWrapper`):**
+    *   Logs entry.
+    *   **Action:** Introduces a 1-second asynchronous delay.
+    *   Logs completion and proceeds.
+    *   ***Behavior with Parallel Calls:*** If two requests (e.g., PAR-1, PAR-2 from `getCitiesInParallel()`) arrive, both will enter this interceptor's `onRequest` handler nearly simultaneously. Their 1-second delays will run concurrently.
+
+2.  **QueuedInterceptor2 (`QueuedInterceptorsWrapper`):**
+    *   Logs entry with "...queueing for sequential processing..."
+    *   **Action:** Introduces a 2-second asynchronous delay.
+    *   Logs completion with "...Sequential processing completed..." and proceeds.
+    *   ***Behavior with Parallel Calls:***
+        *   If PAR-1 enters, it starts its 2-second delay.
+        *   If PAR-2 arrives while PAR-1 is in its delay, PAR-2's `onRequest` in *this specific interceptor* will **wait**. It will not start its 2-second delay until PAR-1 has finished its 2-second delay *and* its `onRequest` handler in `QueuedInterceptor2` has called `handler.next()`.
+        *   Processing through `QueuedInterceptor2.onRequest` is strictly sequential. The same logic applies to `onResponse` and `onError` within this interceptor.
+
+3.  **Interceptor3 (`InterceptorsWrapper`):**
+    *   Logs entry.
+    *   **Action:** Synchronously adds API key, language, and unit parameters to the request.
+    *   Proceeds.
+
+4.  **`LogInterceptor`:**
+    *   Standard Dio interceptor.
+    *   **Action:** Logs detailed information about the outgoing request and the incoming response.
+
+5.  **(Network Call to OpenWeatherMap API)**
+
+6.  **Response/Error Handling (in reverse order for `onResponse`/`onError`):**
+    *   `LogInterceptor` logs the response/error.
+    *   **Interceptor3 (`InterceptorsWrapper`):** Logs entry for `onResponse`.
+    *   **QueuedInterceptor2 (`QueuedInterceptorsWrapper`):** Logs entry for `onResponse`/`onError`, performs its 2-second delay *sequentially*, logs completion, and proceeds.
+    *   **Interceptor1 (`InterceptorsWrapper`):** Logs entry for `onResponse`.
+    *   **Error-Specific Interceptor (`InterceptorsWrapper`):** If an error occurs and isn't handled/resolved by `QueuedInterceptor2`, this shows a "Network error!" Snackbar with a retry option.
+
+**Key Difference: `InterceptorsWrapper` vs. `QueuedInterceptorsWrapper`**
+
+*   **`InterceptorsWrapper` (Interceptor1 and Interceptor3):**
+    *   **Concurrency:** Handlers (`onRequest`, `onResponse`, `onError`) for different requests can execute concurrently. Asynchronous operations within these handlers for multiple requests run in parallel.
+    *   **Use Cases:** General logging, simple header/parameter manipulation, transformations safe for concurrent execution.
+
+*   **`QueuedInterceptorsWrapper` (QueuedInterceptor2):**
+    *   **Concurrency:** No concurrency for handlers of the same type (e.g., all `onRequest` are queued). One request must fully complete its `onRequest` logic (including `await`s before `handler.next()`) before the next request's `onRequest` begins in this interceptor. The same applies independently to `onResponse` and `onError` handlers.
+    *   **Use Cases:** For critical operations that require strict sequencing, such as token refresh processes or maintaining exclusive access to a shared resource while modifying requests or responses.
+
+This explanation, combined with the console logs (which include timestamps and request IDs like "PAR-1", "SEQ-1"), helps in understanding the execution flow.
+
+
+Execution logs for Sequential calls
+
+### 2 APIs ([SEQ-1] and [SEQ-2]) called in sequence
+onRequest chain:
+``` yaml
+21.925 [SEQ-1] onRequest: Interceptor1 - Entered
+22.931 [SEQ-1] onRequest: Interceptor1 - Completed, calling next()
+22.933 [SEQ-1] onRequest: QueuedInterceptor2 - Entered, queueing for sequential processing...
+24.936 [SEQ-1] onRequest: QueuedInterceptor2 - Sequential processing completed, calling next()
+24.938 [SEQ-1] onRequest: Interceptor3 - Entered
+27.887 [SEQ-2] onRequest: Interceptor1 - Entered
+28.889 [SEQ-2] onRequest: Interceptor1 - Completed, calling next()
+28.889 [SEQ-2] onRequest: QueuedInterceptor2 - Entered, queueing for sequential processing...
+30.892 [SEQ-2] onRequest: QueuedInterceptor2 - Sequential processing completed, calling next()
+30.893 [SEQ-2] onRequest: Interceptor3 - Entered
+```
+
+onResponse chain:
+``` yaml
+25.869 [SEQ-1] onResponse: Interceptor1 - Entered
+25.871 [SEQ-1] onResponse: QueuedInterceptor2 - Entered, queueing for sequential processing...
+27.874 [SEQ-1] onResponse: QueuedInterceptor2 - Sequential processing completed, calling next()
+27.875 [SEQ-1] onResponse: Interceptor3 - Entered
+31.683 [SEQ-2] onResponse: Interceptor1 - Entered
+31.684 [SEQ-2] onResponse: QueuedInterceptor2 - Entered, queueing for sequential processing...
+33.686 [SEQ-2] onResponse: QueuedInterceptor2 - Sequential processing completed, calling next()
+33.686 [SEQ-2] onResponse: Interceptor3 - Entered
+```
+
+
+### 2 APIs ([PAR-1] and [PAR-2]) called in parallel
+onRequest chain:
+``` yaml
+28.177 [PAR-1] onRequest: Interceptor1 - Entered
+28.179 [PAR-2] onRequest: Interceptor1 - Entered
+29.183 [PAR-1] onRequest: Interceptor1 - Completed, calling next()
+29.183 [PAR-2] onRequest: Interceptor1 - Completed, calling next()
+29.184 [PAR-1] onRequest: QueuedInterceptor2 - Entered, queueing for sequential processing...
+31.186 [PAR-1] onRequest: QueuedInterceptor2 - Sequential processing completed, calling next()
+31.187 [PAR-2] onRequest: QueuedInterceptor2 - Entered, queueing for sequential processing...
+31.187 [PAR-1] onRequest: Interceptor3 - Entered
+33.189 [PAR-2] onRequest: QueuedInterceptor2 - Sequential processing completed, calling next()
+33.190 [PAR-2] onRequest: Interceptor3 - Entered
+```
+
+onResponse chain:
+``` yaml
+32.300 [PAR-1] onResponse: Interceptor1 - Entered
+32.300 [PAR-1] onResponse: QueuedInterceptor2 - Entered, queueing for sequential processing...
+33.506 [PAR-2] onResponse: Interceptor1 - Entered
+34.302 [PAR-1] onResponse: QueuedInterceptor2 - Sequential processing completed, calling next()
+34.302 [PAR-2] onResponse: QueuedInterceptor2 - Entered, queueing for sequential processing...
+34.303 [PAR-1] onResponse: Interceptor3 - Entered
+36.305 [PAR-2] onResponse: QueuedInterceptor2 - Sequential processing completed, calling next()
+36.306 [PAR-2] onResponse: Interceptor3 - Entered
+```

--- a/projects/chapters/chapter_08/flutter_dio/lib/list_page.dart
+++ b/projects/chapters/chapter_08/flutter_dio/lib/list_page.dart
@@ -17,7 +17,7 @@ class _ListPageWidgetState extends State<ListPageWidget> {
   @override
   void initState() {
     super.initState();
-    listRequest = repository.getCitiesInParallel();
+    listRequest = repository.getCitiesInSequence();
   }
 
   @override
@@ -26,7 +26,7 @@ class _ListPageWidgetState extends State<ListPageWidget> {
       appBar: AppBar(title: Text("WeatherApp")),
       body: RefreshIndicator(
         onRefresh: () async {
-          var request = repository.getCities();
+          var request = repository.getCitiesInSequence();
           setState(() {
             listRequest = request;
           });

--- a/projects/chapters/chapter_08/flutter_dio/lib/list_page.dart
+++ b/projects/chapters/chapter_08/flutter_dio/lib/list_page.dart
@@ -17,7 +17,7 @@ class _ListPageWidgetState extends State<ListPageWidget> {
   @override
   void initState() {
     super.initState();
-    listRequest = repository.getCities();
+    listRequest = repository.getCitiesInParallel();
   }
 
   @override

--- a/projects/chapters/chapter_08/flutter_dio/lib/list_repository.dart
+++ b/projects/chapters/chapter_08/flutter_dio/lib/list_repository.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_dio/list_model.dart';
 import 'package:flutter_dio/ow_service.dart';
+import 'package:flutter_dio/ow_json_models.dart';
 
 class ListRepository {
   var owService = OWService();
 
   Future<List<WeatherCityItem>> getCities() async {
-    var response = await owService.getOWCities();
-    return response.list
+    var response1 = await owService.getOWCities(requestId: "SEQ-1");
+    var response2 = await owService.getOWCities(requestId: "SEQ-2");
+    return (response1.list + response2.list)
         .map(
           (e) => WeatherCityItem(
             e.id,
@@ -23,5 +25,36 @@ class ListRepository {
           ),
         )
         .toList();
+  }
+
+  Future<List<WeatherCityItem>> getCitiesInParallel() async {
+    // Perform two calls in parallel
+    List<OWCitiesFindResponse> responses = await Future.wait([
+      owService.getOWCities(requestId: "PAR-1"),
+      owService.getOWCities(requestId: "PAR-2"),
+    ]);
+
+    final List<WeatherCityItem> combinedList = [];
+    for (var response in responses) {
+      combinedList.addAll(
+        response.list
+            .map(
+              (e) => WeatherCityItem(
+                e.id,
+                e.name,
+                NetworkImage(
+                  "https://openweathermap.org/img/wn/${e.weather[0].icon}.png",
+                ),
+                e.main.temp_min,
+                e.main.temp,
+                e.main.temp_max,
+                e.wind.deg,
+                e.wind.speed,
+              ),
+            )
+            .toList(),
+      );
+    }
+    return combinedList;
   }
 }

--- a/projects/chapters/chapter_08/flutter_dio/lib/list_repository.dart
+++ b/projects/chapters/chapter_08/flutter_dio/lib/list_repository.dart
@@ -6,9 +6,9 @@ import 'package:flutter_dio/ow_json_models.dart';
 class ListRepository {
   var owService = OWService();
 
-  Future<List<WeatherCityItem>> getCities() async {
-    var response1 = await owService.getOWCities(requestId: "SEQ-1");
-    var response2 = await owService.getOWCities(requestId: "SEQ-2");
+  Future<List<WeatherCityItem>> getCitiesInSequence() async {
+    final response1 = await owService.getOWCities(requestId: "SEQ-1");
+    final response2 = await owService.getOWCities(requestId: "SEQ-2");
     return (response1.list + response2.list)
         .map(
           (e) => WeatherCityItem(


### PR DESCRIPTION
**Summary:**

Enhances the `flutter_dio` sample project to more clearly demonstrate the differences between Dio's `InterceptorsWrapper` and `QueuedInterceptorsWrapper`. It introduces parallel API calls, refines interceptor logging with request IDs and timestamps, and updates the `README.md` with a detailed explanation and example logs. 

**Changelog:**
*   **Feature: Interceptor Behavior Demonstration**
    *   Modified `ListRepository` to include:
        *   `getCitiesInSequence()`: Makes two sequential API calls.
        *   `getCitiesInParallel()`: Makes two parallel API calls using `Future.wait`.
    *   Adjusted interceptors in `OWService`:
        *   `Interceptor1` (`InterceptorsWrapper`): Added a 1-second delay to `onRequest` to make its concurrent nature more observable.
        *   `QueuedInterceptor2` (`QueuedInterceptorsWrapper`): Added a 2-second delay to `onRequest`, `onResponse`, and `onError` handlers to clearly demonstrate its sequential processing of concurrent requests.
*   **Feature: Enhanced Logging**
    *   Introduced unique `requestId` (e.g., "SEQ-1", "PAR-1") for API calls, which are now included in all interceptor `debugPrint` logs for easy tracing.

